### PR TITLE
Add PHP_CodeSniffer in Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ sudo: false
 before_script:
     - travis_retry composer self-update
     - travis_retry composer install --no-interaction --prefer-dist
+    - ./vendor/bin/phpcs -n --standard=PSR2 src/ tests/

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.5"
+        "phpunit/phpunit": "^5.7 || ^6.5",
+        "squizlabs/php_codesniffer": "^3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Changed log
- Add `PHP_CodeSniffer` tool to check the PSR-2 coding style in Travis CI build. and add `-n` option argument to skip warnings during `PHP_CodeSniffer` execution.