### PR TITLE
Fix utf8 implementation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="HJSON Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="HJSON Test Suite">

--- a/src/HJSON/HJSONParser.php
+++ b/src/HJSON/HJSONParser.php
@@ -345,7 +345,11 @@ class HJSONParser
     private function peek($offs)
     {
         // range check is not required
-        return mb_substr(mb_strcut($this->text, $this->at), $offs, 1);
+        if ($offs >= 0) {
+            return mb_substr(mb_strcut($this->text, $this->at), $offs, 1);
+        } else {
+            return mb_substr(mb_strcut($this->text, 0, $this->at), $offs, 1);
+        }
     }
 
     private function skipIndent($indent)

--- a/src/HJSON/HJSONParser.php
+++ b/src/HJSON/HJSONParser.php
@@ -302,18 +302,32 @@ class HJSONParser
 
     private function error($m)
     {
-        $i=0;
         $col=0;
+        $colBytes = 0;
         $line=1;
         for ($i = $this->at-1; $i > 0 && @$this->text[$i] !== "\n"; $i--, $col++) {
         }
+
+        $i = $this->at;
+        while ($i > 0) {
+            $ch = mb_substr(mb_strcut($this->text, $i - 1), 0, 1);
+            $i += strlen($ch);
+
+            if ($ch === "\n") {
+                break;
+            }
+
+            $col++;
+            $colBytes += strlen($ch);
+        }
+
         for (; $i > 0;
         $i--) {
             if ($this->text[$i] === "\n") {
                 $line++;
             }
         }
-        throw new HJSONException("$m at line $line, $col >>>". mb_substr($this->text, $this->at - $col, 20) ." ...");
+        throw new HJSONException("$m at line $line, $col >>>". mb_substr(mb_strcut($this->text, $this->at - $colBytes), 0, 20) ." ...");
     }
 
     private function next($c = false)
@@ -327,14 +341,14 @@ class HJSONParser
         // Get the next character. When there are no more characters,
         // return the empty string.
         $this->ch = (strlen($this->text) > $this->at) ? mb_substr(mb_strcut($this->text, $this->at), 0, 1) : null;
-        $this->at = $this->at + strlen($this->ch);
+        $this->at += strlen($this->ch);
         return $this->ch;
     }
 
     private function peek($offs)
     {
         // range check is not required
-        return $this->text[$this->at + $offs];
+        return mb_substr(mb_strcut($this->text, $this->at), $offs, 1);
     }
 
     private function skipIndent($indent)

--- a/src/HJSON/HJSONParser.php
+++ b/src/HJSON/HJSONParser.php
@@ -305,13 +305,10 @@ class HJSONParser
         $col=0;
         $colBytes = 0;
         $line=1;
-        for ($i = $this->at-1; $i > 0 && @$this->text[$i] !== "\n"; $i--, $col++) {
-        }
 
         $i = $this->at;
         while ($i > 0) {
-            $ch = mb_substr(mb_strcut($this->text, $i - 1), 0, 1);
-            $i += strlen($ch);
+            $i -= strlen($ch);
 
             if ($ch === "\n") {
                 break;

--- a/src/HJSON/HJSONParser.php
+++ b/src/HJSON/HJSONParser.php
@@ -308,6 +308,7 @@ class HJSONParser
 
         $i = $this->at;
         while ($i > 0) {
+            $ch = mb_substr(mb_strcut($this->text, $i - 1), 0, 1);
             $i -= strlen($ch);
 
             if ($ch === "\n") {

--- a/src/HJSON/HJSONParser.php
+++ b/src/HJSON/HJSONParser.php
@@ -326,8 +326,8 @@ class HJSONParser
 
         // Get the next character. When there are no more characters,
         // return the empty string.
-        $this->ch = (mb_strlen($this->text) > $this->at) ? $this->text[$this->at] : null;
-        $this->at++;
+        $this->ch = (strlen($this->text) > $this->at) ? mb_substr(mb_strcut($this->text, $this->at), 0, 1) : null;
+        $this->at = $this->at + strlen($this->ch);
         return $this->ch;
     }
 

--- a/tests/HJSONParserTest.php
+++ b/tests/HJSONParserTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class HJSONParserTest extends TestCase
 {
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->rootDir = dirname(__FILE__).DIRECTORY_SEPARATOR."assets";

--- a/tests/HJSONParserTest.php
+++ b/tests/HJSONParserTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class HJSONParserTest extends TestCase
 {
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->rootDir = dirname(__FILE__).DIRECTORY_SEPARATOR."assets";

--- a/tests/HJSONParserTest.php
+++ b/tests/HJSONParserTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class HJSONParserTest extends TestCase
 {
 
-    protected function setUp(): void
+    public function setUp()
     {
         parent::setUp();
         $this->rootDir = dirname(__FILE__).DIRECTORY_SEPARATOR."assets";

--- a/tests/assets/charset_result.hjson
+++ b/tests/assets/charset_result.hjson
@@ -1,5 +1,5 @@
 {
-  ql-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
-  js-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
-  ml-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+  ql-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé
+  js-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé
+  ml-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé
 }

--- a/tests/assets/charset_result.json
+++ b/tests/assets/charset_result.json
@@ -1,5 +1,5 @@
 {
-  "ql-ascii": "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
-  "js-ascii": "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
-  "ml-ascii": "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  "ql-ascii": "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé",
+  "js-ascii": "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé",
+  "ml-ascii": "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé"
 }

--- a/tests/assets/charset_test.hjson
+++ b/tests/assets/charset_test.hjson
@@ -1,6 +1,6 @@
-ql-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
-js-ascii: "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+ql-ascii: ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé
+js-ascii: "! \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé"
 ml-ascii:
   '''
-  ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+  ! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÄäÅåÖöÉé
   '''


### PR DESCRIPTION
Fixes #14 

It looks like everything was built with utf8 strings in mind, but the parser implementation always counted in bytes, not characters. With this fix, `$this->ch` can now be a multi-byte utf8 character, but `$this->at` still counts up bytes. I've hopefully fixed the `next()`, `peek()`, and `error()`, and I think that's all that needs to be fixed, but I would like someone else to go over my changes as well.

Something to note about this code is that the php function `mb_substr` counts in characters whereas `mb_strcut` counts (safely) in bytes. So in several places I will use `mb_substr(mb_strcut($str, $pos), 0, $len)` where `$pos` is in bytes and `$len` is in characters.