### PR TITLE
Add () when instantiating the class to follow PER standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ use HJSON\HJSONStringifier;
 $parser = new HJSONParser();
 $obj = $parser->parse(hjsonText);
 
-$stringifier = new HJSONStringifier;
+$stringifier = new HJSONStringifier();
 $text = $stringifier->stringify($obj);
 ```
 
@@ -79,8 +79,8 @@ This method produces Hjson text from a value.
 You can modify a Hjson file and keep the whitespace & comments intact. This is useful if an app updates its config file.
 
 ```
-$parser = new HJSONParser;
-$stringifier = new HJSONStringifier;
+$parser = new HJSONParser();
+$stringifier = new HJSONStringifier();
 
 $text = "{
   # specify rate in requests/second (because comments are helpful!)

--- a/src/HJSON/HJSONParser.php
+++ b/src/HJSON/HJSONParser.php
@@ -211,12 +211,12 @@ class HJSONParser
     {
         // Parse an object value.
         $key = null;
-        $object = new \stdClass;
+        $object = new \stdClass();
         $kw = null;
         $wat = null;
         if ($this->keepWsc) {
-            $kw = new \stdClass;
-            $kw->c = new \stdClass;
+            $kw = new \stdClass();
+            $kw->c = new \stdClass();
             $kw->o = [];
             $object->__WSC__ = $kw;
             if ($withoutBraces) {

--- a/tests/HJSONParserTest.php
+++ b/tests/HJSONParserTest.php
@@ -155,6 +155,6 @@ class HJSONParserTest
     }
 }
 
-$tester = new HJSONParserTest;
+$tester = new HJSONParserTest();
 $tester->setUp();
 $tester->testAll();


### PR DESCRIPTION
Add the `()` in the constructor call for consistency (and follow PHP standards too).

Reference to the standard: https://www.php-fig.org/per/coding-style/#4-classes-properties-and-methods.