### PR TITLE
Fix for PHP8.2 deprecation - property must be defined in class, not dynamically

### DIFF
--- a/src/HJSON/HJSONStringifier.php
+++ b/src/HJSON/HJSONStringifier.php
@@ -24,6 +24,7 @@ class HJSONStringifier
     private $needsEscapeName = '/[,\{\[\}\]\s:#"\']|\/\/|\/\*|\'\'\'/';
     private $gap = '';
     private $indent = '  ';
+	private $meta = null;
 
     // options
     private $eol;

--- a/src/HJSON/HJSONStringifier.php
+++ b/src/HJSON/HJSONStringifier.php
@@ -24,7 +24,7 @@ class HJSONStringifier
     private $needsEscapeName = '/[,\{\[\}\]\s:#"\']|\/\/|\/\*|\'\'\'/';
     private $gap = '';
     private $indent = '  ';
-	private $meta = null;
+    private $meta = null;
 
     // options
     private $eol;


### PR DESCRIPTION
Set private $meta in class definition to avoid deprecation warning about dynamically set property.